### PR TITLE
Fix: Correct group chat behavior and channel message subscription

### DIFF
--- a/middlewares/subscription.py
+++ b/middlewares/subscription.py
@@ -15,10 +15,32 @@ class SubscriptionMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: Dict[str, Any]
     ) -> Any:
-        if isinstance(event, Message) and event.from_user:
-            user_id = event.from_user.id
-            if not await self.subscription_manager.is_subscriber(user_id, data["bot"]):
-                await event.answer(f"To use this bot, you need to be a subscriber of {CHANNEL_ID} channel.")
-                return
+        # Ensure CHANNEL_ID is treated as a string for comparison, as Telegram IDs can be large numbers.
+        # Sender chat ID and CHANNEL_ID from config might be int or str depending on source.
+        config_channel_id_str = str(CHANNEL_ID)
 
+        if isinstance(event, Message):
+            # Case 1: Message sent by the configured CHANNEL_ID (e.g., admin posting in channel, or channel auto-forwarding to linked group)
+            if event.sender_chat and str(event.sender_chat.id) == config_channel_id_str:
+                logger.info(f"Message from configured CHANNEL_ID ({config_channel_id_str}), chat_id={event.chat.id}, sender_chat_id={event.sender_chat.id}. Bypassing user subscription check.")
+                return await handler(event, data) # Allow message to proceed
+
+            # Case 2: Message from a regular user (not the channel itself via sender_chat)
+            elif event.from_user:
+                user_id = event.from_user.id
+                logger.info(f"Checking subscription for user_id {user_id} in chat_id {event.chat.id}.")
+                if not await self.subscription_manager.is_subscriber(user_id, data["bot"]):
+                    logger.info(f"User {user_id} is not subscribed. Blocking message in chat {event.chat.id}.")
+                    await event.answer(f"To use this bot, you need to be a subscriber of the {CHANNEL_ID} channel.")
+                    return # Block message
+                else:
+                    logger.info(f"User {user_id} is subscribed. Allowing message.")
+                    # Fall through to return await handler(event, data) at the end
+            
+            # Case 3: Other message types or scenarios (e.g. message not from user, not from sender_chat, service messages)
+            else:
+                logger.debug(f"Message event (type: {type(event)}, chat_id: {event.chat.id}) is not from a specific user (event.from_user is None) and not from the configured CHANNEL_ID via sender_chat. Allowing to pass.")
+                # Fall through to return await handler(event, data) at the end
+
+        # Default: Allow event to proceed if none of the above conditions resulted in a return
         return await handler(event, data)

--- a/routers/messages.py
+++ b/routers/messages.py
@@ -34,85 +34,95 @@ async def handle_group_message(message: Message, session_manager, openai_client,
 
     # Check if the message is a direct command /ask (processed separately)
     if message_text.startswith("/ask"):
-        logger.debug("Ignoring message starting with /ask in group message handler.")
+        logger.debug("Ignoring message starting with /ask in group message handler as it's handled by command handler.")
         return
+
+    # New requirement: Bot should ONLY respond to /ask commands in groups.
+    # All other messages, including mentions and replies, should be ignored by this handler.
+    # Therefore, if the message is not an /ask command, we do nothing further.
+    logger.debug(f"Ignoring non-/ask message in group chat: '{message_text}'")
+    return
+
+    # The following code for handling mentions, replies, and general processing
+    # is now effectively bypassed due to the return statement above for non-/ask messages.
+    # It is kept here (commented out or unreachable) for reference or future changes if requirements evolve.
 
     # --- Check if the bot should process this message ---
-    bot_mentioned = False
-    is_reply_to_bot = False
-
-    # Check for @username mention
-    if f"@{bot_username}" in message_text:
-        bot_mentioned = True
-        logger.debug("Bot mentioned by username.")
-
-    # Check for entity mention
-    if not bot_mentioned and message.entities:
-        for entity in message.entities:
-            if entity.type == "mention" and message_text[entity.offset:entity.offset+entity.length] == f"@{bot_username}":
-                bot_mentioned = True
-                logger.debug("Bot mentioned by entity.")
-                break
-            elif entity.type == "text_mention" and entity.user and entity.user.id == bot_id:
-                bot_mentioned = True
-                logger.debug("Bot mentioned by text_mention entity.")
-                break
-
-    # Check if this is a reply to a bot message
-    if message.reply_to_message and message.reply_to_message.from_user and (
-        message.reply_to_message.from_user.id == bot_id or
-        message.reply_to_message.from_user.username == bot_username
-    ):
-        is_reply_to_bot = True
-        logger.debug("Message is a reply to the bot.")
-
-    # If the bot is neither mentioned nor replied to, ignore the message
-    if not bot_mentioned and not is_reply_to_bot:
-        logger.debug("Ignoring group message: No mention and not a reply to the bot.")
-        return
-    # --- End Check ---
-
-    user_id = message.from_user.id
-    user_message = message_text # Start with the full text
-
-    # If the bot was mentioned, remove the mention for processing
-    if bot_mentioned:
-        user_message = user_message.replace(f"@{bot_username}", "").strip()
-        logger.debug(f"Removed mention, message to process: '{user_message}'")
-
-    # If this is a reply to the bot, add context from the replied message
-    # Prepend context only if it's a reply and the message text isn't empty
-    if is_reply_to_bot and message.reply_to_message.text and user_message:
-        replied_text = message.reply_to_message.text
-        user_message = f"Context: {replied_text}\n\nQuestion: {user_message}"
-        logger.debug(f"Added context from reply. Message to process: '{user_message}'")
-    elif is_reply_to_bot and not user_message:
-        # If it's a reply but the reply text itself is empty (e.g., just a sticker reply)
-        # We might still want to process it if the original message had text
-        if message.reply_to_message.text:
-             user_message = f"Context: {message.reply_to_message.text}\n\nQuestion: [User replied without text] What do you think about this?"
-             logger.debug("Reply had no text, created default question with context.")
-        else: # Reply to a message without text (e.g. photo) - might need specific handling?
-             logger.debug("Reply to a non-text message without text in reply - ignoring for now.")
-             return # Or maybe process based on original message type?
-
-    if not user_message:
-        logger.debug("After processing mentions/replies, message is empty. Ignoring.")
-        return
-
-    logger.info(f"Processing group message/reply: '{user_message}'")
-
-    session = session_manager.get_or_create_session(user_id)
-    model_provider = session_manager.get_model_provider(user_id)
-
-    try:
-        if model_provider == "anthropic":
-            reply = await claude_client.process_message(session, user_message)
-        else:
-            reply = await openai_client.process_message(session, user_message)
-
-        await message.reply(reply) # Use reply to keep context in group chat
-        logger.info("Successfully processed and replied in group.")
-    except Exception as e:
-        logger.error(f"Error processing group message via AI client: {e}", exc_info=True)
-        await message.reply("Sorry, I encountered an error trying to process that.")
+    # bot_mentioned = False
+    # is_reply_to_bot = False
+    #
+    # # Check for @username mention
+    # if f"@{bot_username}" in message_text:
+    #     bot_mentioned = True
+    #     logger.debug("Bot mentioned by username.")
+    #
+    # # Check for entity mention
+    # if not bot_mentioned and message.entities:
+    #     for entity in message.entities:
+    #         if entity.type == "mention" and message_text[entity.offset:entity.offset+entity.length] == f"@{bot_username}":
+    #             bot_mentioned = True
+    #             logger.debug("Bot mentioned by entity.")
+    #             break
+    #         elif entity.type == "text_mention" and entity.user and entity.user.id == bot_id:
+    #             bot_mentioned = True
+    #             logger.debug("Bot mentioned by text_mention entity.")
+    #             break
+    #
+    # # Check if this is a reply to a bot message
+    # if message.reply_to_message and message.reply_to_message.from_user and (
+    #     message.reply_to_message.from_user.id == bot_id or
+    #     message.reply_to_message.from_user.username == bot_username
+    # ):
+    #     is_reply_to_bot = True
+    #     logger.debug("Message is a reply to the bot.")
+    #
+    # # If the bot is neither mentioned nor replied to, ignore the message
+    # if not bot_mentioned and not is_reply_to_bot:
+    #     logger.debug("Ignoring group message: No mention and not a reply to the bot.")
+    #     return
+    # # --- End Check ---
+    #
+    # user_id = message.from_user.id
+    # user_message = message_text # Start with the full text
+    #
+    # # If the bot was mentioned, remove the mention for processing
+    # if bot_mentioned:
+    #     user_message = user_message.replace(f"@{bot_username}", "").strip()
+    #     logger.debug(f"Removed mention, message to process: '{user_message}'")
+    #
+    # # If this is a reply to the bot, add context from the replied message
+    # # Prepend context only if it's a reply and the message text isn't empty
+    # if is_reply_to_bot and message.reply_to_message.text and user_message:
+    #     replied_text = message.reply_to_message.text
+    #     user_message = f"Context: {replied_text}\n\nQuestion: {user_message}"
+    #     logger.debug(f"Added context from reply. Message to process: '{user_message}'")
+    # elif is_reply_to_bot and not user_message:
+    #     # If it's a reply but the reply text itself is empty (e.g., just a sticker reply)
+    #     # We might still want to process it if the original message had text
+    #     if message.reply_to_message.text:
+    #          user_message = f"Context: {message.reply_to_message.text}\n\nQuestion: [User replied without text] What do you think about this?"
+    #          logger.debug("Reply had no text, created default question with context.")
+    #     else: # Reply to a message without text (e.g. photo) - might need specific handling?
+    #          logger.debug("Reply to a non-text message without text in reply - ignoring for now.")
+    #          return # Or maybe process based on original message type?
+    #
+    # if not user_message:
+    #     logger.debug("After processing mentions/replies, message is empty. Ignoring.")
+    #     return
+    #
+    # logger.info(f"Processing group message/reply: '{user_message}'")
+    #
+    # session = session_manager.get_or_create_session(user_id)
+    # model_provider = session_manager.get_model_provider(user_id)
+    #
+    # try:
+    #     if model_provider == "anthropic":
+    #         reply = await claude_client.process_message(session, user_message)
+    #     else:
+    #         reply = await openai_client.process_message(session, user_message)
+    #
+    #     await message.reply(reply) # Use reply to keep context in group chat
+    #     logger.info("Successfully processed and replied in group.")
+    # except Exception as e:
+    #     logger.error(f"Error processing group message via AI client: {e}", exc_info=True)
+    #     await message.reply("Sorry, I encountered an error trying to process that.")

--- a/tests/middlewares/test_subscription.py
+++ b/tests/middlewares/test_subscription.py
@@ -1,0 +1,204 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiogram.types import Message, User, Chat
+from middlewares.subscription import SubscriptionMiddleware
+from config import CHANNEL_ID # Assuming CHANNEL_ID is accessible for tests
+
+# Ensure CHANNEL_ID is a string for consistent comparison in tests
+TEST_CHANNEL_ID = str(CHANNEL_ID)
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    # If bot.id is accessed, ensure it's available
+    bot.id = 123456789 # Example bot ID
+    return bot
+
+@pytest.fixture
+def mock_subscription_manager():
+    manager = AsyncMock()
+    manager.is_subscriber = AsyncMock()
+    return manager
+
+@pytest.fixture
+def mock_handler():
+    handler = AsyncMock(return_value="handler_called")
+    return handler
+
+@pytest.fixture
+def subscription_middleware(mock_subscription_manager):
+    return SubscriptionMiddleware(subscription_manager=mock_subscription_manager)
+
+@pytest.mark.asyncio
+async def test_scenario_1_1_user_not_subscribed(subscription_middleware, mock_subscription_manager, mock_handler, mock_bot):
+    """Scenario 1.1: User Not Subscribed"""
+    user = User(id=123, is_bot=False, first_name="Test")
+    chat = Chat(id=456, type="private")
+    event_message = Message(
+        message_id=1,
+        chat=chat,
+        from_user=user,
+        text="Hello",
+        bot=mock_bot # Pass the bot mock here
+    )
+    event_message.answer = AsyncMock() # Mock the answer method on the message instance
+
+    mock_subscription_manager.is_subscriber.return_value = False
+    data = {"bot": mock_bot} # Simulate data passed by dispatcher
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message, data=data)
+
+    mock_subscription_manager.is_subscriber.assert_called_once_with(user.id, mock_bot)
+    expected_denial_message = f"To use this bot, you need to be a subscriber of the {TEST_CHANNEL_ID} channel."
+    event_message.answer.assert_called_once_with(expected_denial_message)
+    mock_handler.assert_not_called()
+    assert result is None # Middleware should return, not the handler's result
+
+@pytest.mark.asyncio
+async def test_scenario_1_2_user_subscribed(subscription_middleware, mock_subscription_manager, mock_handler, mock_bot):
+    """Scenario 1.2: User Subscribed"""
+    user = User(id=123, is_bot=False, first_name="Test")
+    chat = Chat(id=456, type="private")
+    event_message = Message(
+        message_id=1,
+        chat=chat,
+        from_user=user,
+        text="Hello",
+        bot=mock_bot
+    )
+    event_message.answer = AsyncMock()
+    mock_subscription_manager.is_subscriber.return_value = True
+    data = {"bot": mock_bot}
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message, data=data)
+
+    mock_subscription_manager.is_subscriber.assert_called_once_with(user.id, mock_bot)
+    event_message.answer.assert_not_called()
+    mock_handler.assert_called_once_with(event_message, data)
+    assert result == "handler_called"
+
+@pytest.mark.asyncio
+async def test_scenario_1_3_message_from_configured_channel(subscription_middleware, mock_subscription_manager, mock_handler, mock_bot):
+    """Scenario 1.3: Message from Configured Channel via sender_chat"""
+    # Case 1.3a: sender_chat.id is CHANNEL_ID, from_user is also present (e.g. admin)
+    admin_user = User(id=789, is_bot=False, first_name="ChannelAdmin")
+    sender_chat_obj = Chat(id=int(TEST_CHANNEL_ID), type="channel", title="Test Channel") # Ensure ID is int if CHANNEL_ID is str
+    group_chat = Chat(id=987, type="group", title="Linked Group") # Message is in a group, but sent by channel
+
+    event_message_admin_sent = Message(
+        message_id=1,
+        chat=group_chat, # Message appears in the group
+        sender_chat=sender_chat_obj, # Identifies actual sender as the channel
+        from_user=admin_user, # Telegram also provides user if admin sends on behalf of channel
+        text="Channel Update",
+        bot=mock_bot
+    )
+    event_message_admin_sent.answer = AsyncMock()
+    data = {"bot": mock_bot}
+
+    # Even if is_subscriber would return False for admin_user.id, it shouldn't be checked, or its result ignored
+    mock_subscription_manager.is_subscriber.return_value = False 
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message_admin_sent, data=data)
+
+    # is_subscriber should NOT be called for the admin_user.id in this specific flow
+    # because the sender_chat check takes precedence.
+    # Or, if it is called due to from_user being present before sender_chat is checked,
+    # the bypass must still occur. The current middleware logic checks sender_chat first.
+    mock_subscription_manager.is_subscriber.assert_not_called() # Ideal, assuming sender_chat is checked first
+    event_message_admin_sent.answer.assert_not_called()
+    mock_handler.assert_called_once_with(event_message_admin_sent, data)
+    assert result == "handler_called"
+
+    # Reset mocks for next sub-case
+    mock_handler.reset_mock()
+    mock_subscription_manager.reset_mock() # reset all mocks on manager
+    mock_subscription_manager.is_subscriber = AsyncMock(return_value=False) # re-assign async mock
+
+    # Case 1.3b: sender_chat.id is CHANNEL_ID, from_user is None (e.g. automated channel message)
+    event_message_channel_sent = Message(
+        message_id=2,
+        chat=group_chat,
+        sender_chat=sender_chat_obj,
+        from_user=None, # No specific user, just the channel
+        text="Automated Channel Post",
+        bot=mock_bot
+    )
+    event_message_channel_sent.answer = AsyncMock() # Not strictly needed here as no denial expected
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message_channel_sent, data=data)
+    
+    mock_subscription_manager.is_subscriber.assert_not_called()
+    mock_handler.assert_called_once_with(event_message_channel_sent, data)
+    assert result == "handler_called"
+
+@pytest.mark.asyncio
+async def test_non_message_event_passes(subscription_middleware, mock_handler, mock_bot):
+    """Test that non-Message events are passed through without checks."""
+    non_message_event = MagicMock() # Simulate some other TelegramObject
+    data = {"bot": mock_bot}
+
+    result = await subscription_middleware(handler=mock_handler, event=non_message_event, data=data)
+    
+    mock_handler.assert_called_once_with(non_message_event, data)
+    assert result == "handler_called"
+
+@pytest.mark.asyncio
+async def test_message_without_from_user_or_sender_chat_passes(subscription_middleware, mock_handler, mock_bot):
+    """Test that Message events without from_user and not matching CHANNEL_ID sender_chat pass."""
+    chat = Chat(id=456, type="private")
+    event_message = Message(
+        message_id=1,
+        chat=chat,
+        from_user=None, # No from_user
+        sender_chat=None, # No sender_chat
+        text="System Message?",
+        bot=mock_bot
+    )
+    data = {"bot": mock_bot}
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message, data=data)
+    
+    mock_handler.assert_called_once_with(event_message, data)
+    assert result == "handler_called"
+
+@pytest.mark.asyncio
+async def test_message_from_other_channel_acts_as_user_message(subscription_middleware, mock_subscription_manager, mock_handler, mock_bot):
+    """Message from another channel (not THE CHANNEL_ID) should be treated like a user message,
+       but since from_user is None and sender_chat.id != CHANNEL_ID, it passes through.
+       This confirms the logic of the 'else' case in the middleware for messages.
+    """
+    other_channel_sender = Chat(id=int(TEST_CHANNEL_ID) + 1, type="channel", title="Another Channel")
+    group_chat = Chat(id=987, type="group", title="Linked Group")
+    event_message = Message(
+        message_id=1,
+        chat=group_chat,
+        sender_chat=other_channel_sender, # Message from a channel, but not THE configured one
+        from_user=None, # No specific user
+        text="Post from other channel",
+        bot=mock_bot
+    )
+    data = {"bot": mock_bot}
+    event_message.answer = AsyncMock()
+
+    result = await subscription_middleware(handler=mock_handler, event=event_message, data=data)
+
+    # It should not call is_subscriber because from_user is None
+    mock_subscription_manager.is_subscriber.assert_not_called()
+    # It should not send a denial message
+    event_message.answer.assert_not_called()
+    # It should pass to the handler
+    mock_handler.assert_called_once_with(event_message, data)
+    assert result == "handler_called"
+
+# To run these tests, you would typically use `pytest` in the terminal.
+# Example: `pytest tests/middlewares/test_subscription.py`
+# Ensure config.py with CHANNEL_ID is in a place accessible by PYTHONPATH
+# or mock/patch CHANNEL_ID directly in tests if it's problematic.
+# For simplicity, this test assumes CHANNEL_ID can be imported.
+# One way to ensure TEST_CHANNEL_ID is used:
+# with patch('middlewares.subscription.CHANNEL_ID', TEST_CHANNEL_ID):
+#    # run test
+# This is more robust if config.py is complex or has side effects.
+# For this example, direct import is assumed to work.

--- a/tests/routers/test_group_messages.py
+++ b/tests/routers/test_group_messages.py
@@ -1,0 +1,233 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiogram.types import Message, User, Chat, ChatMemberOwner, ChatMemberMember
+
+# Assuming routers are in 'project_root/routers/'
+# Adjust import paths if your project structure is different
+from routers.messages import handle_group_message
+from routers.commands import handle_ask_command # For Scenario 2.3
+from config import CHANNEL_ID # For any CHANNEL_ID related logic if needed, though not directly here
+
+TEST_BOT_USERNAME = "TestBot"
+TEST_BOT_ID = 987654321
+
+@pytest.fixture
+def mock_bot_instance():
+    """Mocks the bot instance (message.bot.me())"""
+    bot_user = User(id=TEST_BOT_ID, is_bot=True, first_name=TEST_BOT_USERNAME, username=TEST_BOT_USERNAME)
+    bot_instance = AsyncMock()
+    bot_instance.me = AsyncMock(return_value=bot_user)
+    return bot_instance
+
+@pytest.fixture
+def mock_session_manager():
+    manager = MagicMock()
+    manager.get_or_create_session = MagicMock(return_value="session_obj")
+    manager.get_model_provider = MagicMock(return_value="openai") # Default mock provider
+    return manager
+
+@pytest.fixture
+def mock_openai_client():
+    client = AsyncMock()
+    client.process_message = AsyncMock(return_value="Mocked AI response")
+    return client
+
+@pytest.fixture
+def mock_claude_client(): # Though not used in /ask by default, good to have
+    client = AsyncMock()
+    client.process_message = AsyncMock(return_value="Mocked Claude response")
+    return client
+
+@pytest.fixture
+def group_chat():
+    return Chat(id=-100123456789, type="group", title="Test Group")
+
+@pytest.fixture
+def regular_user():
+    return User(id=12345, is_bot=False, first_name="Test User")
+
+# --- Tests for routers.messages.handle_group_message ---
+
+@pytest.mark.asyncio
+async def test_scenario_2_1_bot_mention_in_group_ignored(
+    mock_bot_instance, mock_session_manager, mock_openai_client, mock_claude_client, group_chat, regular_user
+):
+    """Scenario 2.1: Bot Mention in Group - No Response from handle_group_message"""
+    message_text = f"@{TEST_BOT_USERNAME} hello there!"
+    message = Message(
+        message_id=100,
+        chat=group_chat,
+        from_user=regular_user,
+        text=message_text,
+        bot=mock_bot_instance
+    )
+    message.reply = AsyncMock()
+
+    # Directly call handle_group_message
+    await handle_group_message(
+        message, 
+        session_manager=mock_session_manager, 
+        openai_client=mock_openai_client, 
+        claude_client=mock_claude_client
+    )
+
+    # Assert that reply was NOT called because handle_group_message should ignore non-/ask
+    message.reply.assert_not_called()
+    # Assert AI client was NOT called by this handler
+    mock_openai_client.process_message.assert_not_called()
+    mock_claude_client.process_message.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_scenario_2_2_bot_reply_in_group_ignored(
+    mock_bot_instance, mock_session_manager, mock_openai_client, mock_claude_client, group_chat, regular_user
+):
+    """Scenario 2.2: Bot Reply in Group - No Response from handle_group_message"""
+    bot_previous_message = Message(
+        message_id=100, chat=group_chat, from_user=User(id=TEST_BOT_ID, is_bot=True, first_name=TEST_BOT_USERNAME, username=TEST_BOT_USERNAME), text="I am a bot."
+    )
+    message = Message(
+        message_id=101,
+        chat=group_chat,
+        from_user=regular_user,
+        text="Oh really?",
+        reply_to_message=bot_previous_message,
+        bot=mock_bot_instance
+    )
+    message.reply = AsyncMock()
+
+    await handle_group_message(
+        message, 
+        session_manager=mock_session_manager, 
+        openai_client=mock_openai_client, 
+        claude_client=mock_claude_client
+    )
+
+    message.reply.assert_not_called()
+    mock_openai_client.process_message.assert_not_called()
+    mock_claude_client.process_message.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_general_group_message_ignored(
+    mock_bot_instance, mock_session_manager, mock_openai_client, mock_claude_client, group_chat, regular_user
+):
+    """Test that a general group message (no mention, no reply, not /ask) is ignored."""
+    message = Message(
+        message_id=102,
+        chat=group_chat,
+        from_user=regular_user,
+        text="Just a random message.",
+        bot=mock_bot_instance
+    )
+    message.reply = AsyncMock()
+
+    await handle_group_message(
+        message, 
+        session_manager=mock_session_manager, 
+        openai_client=mock_openai_client, 
+        claude_client=mock_claude_client
+    )
+
+    message.reply.assert_not_called()
+    mock_openai_client.process_message.assert_not_called()
+    mock_claude_client.process_message.assert_not_called()
+
+# --- Test for routers.commands.handle_ask_command in group context ---
+# This implicitly tests that handle_group_message ignores /ask,
+# and handle_ask_command processes it.
+
+@pytest.mark.asyncio
+async def test_scenario_2_3_ask_command_in_group_processed_by_command_handler(
+    mock_bot_instance, mock_session_manager, mock_openai_client, mock_claude_client, group_chat, regular_user
+):
+    """Scenario 2.3: /ask command in Group - Response Expected from handle_ask_command"""
+    
+    # Part 1: Verify handle_group_message ignores /ask
+    ask_message_text_group = "/ask How are you in a group?"
+    group_ask_message = Message(
+        message_id=200,
+        chat=group_chat, # Group context
+        from_user=regular_user,
+        text=ask_message_text_group,
+        bot=mock_bot_instance,
+        entities=[{'type': 'bot_command', 'offset': 0, 'length': 4}] # Simulate command entity
+    )
+    group_ask_message.reply = AsyncMock()
+    group_ask_message.answer = AsyncMock() # For commands, .answer might also be used by some frameworks/handlers
+
+    # Call handle_group_message and ensure it does nothing with /ask
+    await handle_group_message(
+        group_ask_message, 
+        session_manager=mock_session_manager, 
+        openai_client=mock_openai_client, 
+        claude_client=mock_claude_client
+    )
+    group_ask_message.reply.assert_not_called() # handle_group_message should not reply
+    mock_openai_client.process_message.assert_not_called() # handle_group_message should not call AI
+    mock_claude_client.process_message.assert_not_called()
+
+    # Reset mocks for AI clients before calling the command handler
+    mock_openai_client.process_message.reset_mock()
+    mock_claude_client.process_message.reset_mock()
+    mock_openai_client.process_message.return_value = "AI reply to /ask in group"
+
+
+    # Part 2: Verify handle_ask_command processes /ask in a group
+    # We need to mock get_chat_member for admin check in handle_ask_command
+    # For this test, assume user is NOT an admin to simplify, or mock admin status if needed for full coverage
+    mock_bot_instance.get_chat_member = AsyncMock(return_value=ChatMemberMember(user=regular_user, status="member"))
+
+    # Create a new state mock for the command handler
+    mock_state = AsyncMock()
+    mock_state.get_state = AsyncMock(return_value=None) # Default to no state
+    mock_state.set_state = AsyncMock()
+    mock_state.update_data = AsyncMock()
+    mock_state.clear = AsyncMock()
+
+    await handle_ask_command(
+        group_ask_message, # Use the same message object
+        session_manager=mock_session_manager,
+        openai_client=mock_openai_client,
+        claude_client=mock_claude_client, # Pass claude_client as well
+        state=mock_state, # Pass the mock_state
+        bot=mock_bot_instance # Pass the bot instance
+    )
+
+    # Assert AI client (OpenAI by default in session_manager mock) was called by handle_ask_command
+    mock_openai_client.process_message.assert_called_once()
+    # Assert a reply was sent by handle_ask_command
+    group_ask_message.reply.assert_called_once_with("AI reply to /ask in group")
+
+
+# To run these tests:
+# pytest tests/routers/test_group_messages.py
+# Ensure that the routers and config are importable (PYTHONPATH setup).
+# The structure of these tests assumes that handle_group_message is registered for general text
+# and handle_ask_command is registered for /ask commands, and the dispatcher routes correctly.
+# These tests directly call the handlers to verify their internal logic given specific inputs.
+# Testing the dispatcher itself would require more complex Aiogram-specific testing utilities.
+#
+# Note on CHANNEL_ID: The original task description for handle_group_message mentioned CHANNEL_ID,
+# but the implementation change for handle_group_message was to ignore all non-/ask messages.
+# So CHANNEL_ID logic is primarily in SubscriptionMiddleware, not directly in handle_group_message's new logic.
+# The handle_ask_command might have its own considerations for CHANNEL_ID if it needs to behave
+# differently when the bot is used in its own channel's linked group, but that's outside current scope.
+# For now, CHANNEL_ID is imported but not actively used in these specific router tests.
+#
+# For `handle_ask_command`, it includes admin checks using `message.bot.get_chat_member`.
+# This is mocked in `test_scenario_2_3_ask_command_in_group_processed_by_command_handler`.
+# If `handle_ask_command` had more complex logic based on admin status, further test cases would be needed.
+# The provided test assumes a non-admin user for simplicity of the AI call path.
+#
+# Also, `handle_ask_command` uses `FSMContext` (state). A mock for this is added.
+# The `bot` argument has been added to `handle_ask_command` call as it's used internally.
+#
+# The `claude_client` is passed to `handle_ask_command` for completeness, matching its signature.
+#
+# Added `entities` to the mock message for `/ask` command as Aiogram relies on this for command detection.
+# `message.bot` is now properly `mock_bot_instance` in `handle_ask_command` call.
+# `message.answer` is also mocked for `group_ask_message` as command handlers might use it.
+# `mock_bot_instance.get_chat_member` is added to simulate the admin check.
+# `claude_client` argument added to `handle_ask_command` call.
+# `state` argument added to `handle_ask_command` call.
+# `bot` argument added to `handle_ask_command` call.


### PR DESCRIPTION
This commit addresses two issues:

1.  Channel messages incorrectly flagged for subscription:
    - Modified `SubscriptionMiddleware` to correctly identify messages sent on behalf of the configured `CHANNEL_ID` (via `sender_chat`).
    - These messages now bypass the individual user subscription check, allowing admins to post on behalf of the channel in its linked group without needing their personal account to be subscribed.
    - Regular user messages are still subject to subscription checks.

2.  Bot responds to non-/ask messages in groups:
    - Updated `routers/messages.py:handle_group_message` to ensure that in group chats, the bot only processes messages that are `/ask` commands.
    - General mentions of the bot or replies to the bot's messages in group chats (that are not `/ask` commands) are now ignored. `/ask` commands are handled by `routers/commands.py:handle_ask_command`.

Unit tests have been added to cover these changes in behavior for both the middleware and group message handling.