### PR TITLE
Handle /ask captions on photos

### DIFF
--- a/routers/commands.py
+++ b/routers/commands.py
@@ -304,17 +304,11 @@ async def cmd_insta(message: Message, instaloader_client):
     except Exception as e:
         logger.error(f"Error deleting message: {e}")
 
-@router.message(Command("ask"))
+@router.message(Command("ask"), ~F.photo)
 async def handle_ask_command(message: Message, session_manager, openai_client, claude_client):
     user_id = message.from_user.id
 
     # Extract the actual question (remove the /ask part)
-    # Command filter also triggers on captions for media messages. In that case
-    # we want the media-specific handlers to process the request so we simply
-    # skip here.
-    if message.photo:
-        return
-
     question_source = message.text or message.caption or ""
     question = question_source.replace("/ask", "", 1).strip()
     if not question:

--- a/routers/commands.py
+++ b/routers/commands.py
@@ -309,7 +309,14 @@ async def handle_ask_command(message: Message, session_manager, openai_client, c
     user_id = message.from_user.id
 
     # Extract the actual question (remove the /ask part)
-    question = message.text.replace("/ask", "", 1).strip()
+    # Command filter also triggers on captions for media messages. In that case
+    # we want the media-specific handlers to process the request so we simply
+    # skip here.
+    if message.photo:
+        return
+
+    question_source = message.text or message.caption or ""
+    question = question_source.replace("/ask", "", 1).strip()
     if not question:
         await message.answer("Please provide a question after /ask")
         return

--- a/routers/media.py
+++ b/routers/media.py
@@ -41,6 +41,9 @@ async def handle_private_photo(message: Message, session_manager, openai_client,
                                     caption = msg.caption
                                     break
 
+                            if caption and caption.startswith("/ask"):
+                                caption = caption.replace("/ask", "", 1).strip()
+
                             if not caption:
                                 caption = "What is in this image?"
 
@@ -67,6 +70,8 @@ async def handle_private_photo(message: Message, session_manager, openai_client,
     else:
         # Single image handling
         caption = message.caption or "What is in this image?"
+        if caption.startswith("/ask"):
+            caption = caption.replace("/ask", "", 1).strip()
         file = await message.bot.get_file(message.photo[-1].file_id)
         file_url = file.file_path
 


### PR DESCRIPTION
## Summary
- skip `/ask` command handler when the message contains a photo
- detect caption text for `/ask` command
- trim `/ask` prefix from photo captions when handling media

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6849db7fce0c832e806019454c5d992b