### PR TITLE
Fix Instaloader download path check

### DIFF
--- a/clients/instaloader.py
+++ b/clients/instaloader.py
@@ -28,12 +28,9 @@ class InstaloaderClient:
 
             # Try to download
             logger.info(f"Downloading video to {filename}")
-            download_success = self.loader.download_post(post, target=shortcode)
+            self.loader.download_post(post, target=shortcode)
 
-            if download_success:
-                return True, filename
-
-            # If download returned False, check if file exists
+            # Verify if file exists after attempting download
             if os.path.exists(filename):
                 return True, filename
             else:


### PR DESCRIPTION
## Summary
- update download_video to always verify that the file exists after calling `Instaloader.download_post`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6849dbc8b9d4832ebba7734ebef01835