### PR TITLE
Add Instagram session management modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Telegram bot that integrates with OpenAI and Claude AI models to provide intel
 - Image processing and analysis
 - Media group handling
 - Instagram video downloading
+- Automatic Instagram login with shared Redis session
 - Group chat support with mention handling
 - Model switching between OpenAI and Claude
 
@@ -23,7 +24,10 @@ project/
 │   ├── openai_client.py     # OpenAI API integration
 │   ├── claude_client.py     # Claude API integration
 │   ├── flux_client.py       # Image generation API
-│   └── instaloader.py       # Instagram content downloader
+│   ├── instaloader.py       # Instagram content downloader
+│   └── ig_client.py         # Instagram GraphQL facade
+├── redis_client.py          # Redis Sentinel connector
+├── session_store.py         # Redis-based Instagram session cache
 ├── routers/                 # Message routers
 │   ├── commands.py          # Command handlers
 │   ├── messages.py          # Text message handlers

--- a/ig_client.py
+++ b/ig_client.py
@@ -1,0 +1,80 @@
+import asyncio
+import httpx
+import instaloader
+from typing import Any, Dict
+
+from settings import IG_USERNAME, IG_PASSWORD, IG_LOGIN_TIMEOUT_SEC
+from session_store import IgSessionStore
+from utils.logging_config import logger
+
+
+class IgClient:
+    GRAPHQL_URL = "https://www.instagram.com/graphql/query/"
+
+    def __init__(self, store: IgSessionStore):
+        self.store = store
+        self.loader = instaloader.Instaloader(
+            download_comments=False,
+            download_geotags=False,
+            download_pictures=False,
+            download_video_thumbnails=False,
+            save_metadata=False,
+        )
+        self.context = self.loader.context
+        self._loaded = False
+
+    async def ensure_session(self) -> None:
+        if self._loaded:
+            return
+        data = await self.store.get_session(IG_USERNAME)
+        if data:
+            self.context.load_session_from_dict(IG_USERNAME, data["cookies"])
+            await self.store.touch(IG_USERNAME)
+            self._loaded = True
+            return
+        lock = await self.store.acquire_lock()
+        try:
+            data = await self.store.get_session(IG_USERNAME)
+            if data:
+                self.context.load_session_from_dict(IG_USERNAME, data["cookies"])
+            else:
+                await self.login()
+        finally:
+            await lock.release()
+        self._loaded = True
+
+    async def login(self) -> None:
+        logger.info("Logging in to Instagram")
+
+        def _login() -> Dict[str, Any]:
+            self.loader.login(IG_USERNAME, IG_PASSWORD)
+            return self.context.save_session()
+
+        cookies = await asyncio.wait_for(
+            asyncio.to_thread(_login), timeout=IG_LOGIN_TIMEOUT_SEC
+        )
+
+        session_data = {
+            "sessionid": self.context._session.cookies.get("sessionid"),
+            "csrftoken": self.context._session.cookies.get("csrftoken"),
+            "ds_user_id": self.context._session.cookies.get("ds_user_id"),
+            "cookies": cookies,
+        }
+        await self.store.save_session(IG_USERNAME, session_data)
+
+    async def graphql(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        await self.ensure_session()
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            client.cookies.update(self.context._session.cookies.get_dict())
+            resp = await client.get(self.GRAPHQL_URL, params=params)
+            if resp.status_code in (401, 403):
+                logger.warning("Received %s from Instagram", resp.status_code)
+                await self.store.redis.delete(
+                    f"ig:session:{IG_USERNAME}"
+                )
+                self._loaded = False
+                await self.ensure_session()
+                resp = await client.get(self.GRAPHQL_URL, params=params)
+            await self.store.touch(IG_USERNAME)
+            resp.raise_for_status()
+            return resp.json()

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,8 @@
+from prometheus_client import Histogram, Gauge, Counter
+
+ig_session_age_seconds = Gauge(
+    "ig_session_age_seconds", "Age of current Instagram session")
+ig_login_duration_seconds = Histogram(
+    "ig_login_duration_seconds", "Duration of Instagram login")
+ig_login_errors_total = Counter(
+    "ig_login_errors_total", "Number of Instagram login errors")

--- a/redis_client.py
+++ b/redis_client.py
@@ -1,0 +1,39 @@
+from redis.asyncio.sentinel import Sentinel
+from redis.asyncio.client import Redis
+from typing import List, Tuple
+from settings import REDIS_SENTINEL_HOSTS, REDIS_SENTINEL_MASTER, REDIS_PASSWORD
+
+
+def _parse_hosts() -> List[Tuple[str, int]]:
+    hosts = []
+    for item in REDIS_SENTINEL_HOSTS.split(','):
+        if not item:
+            continue
+        host, port = item.split(':')
+        hosts.append((host, int(port)))
+    return hosts
+
+
+class RedisClient:
+    def __init__(self) -> None:
+        self.sentinel = Sentinel(
+            _parse_hosts(),
+            password=REDIS_PASSWORD,
+            socket_timeout=5,
+            sentinel_kwargs={"password": REDIS_PASSWORD},
+        )
+
+    def get_master(self) -> Redis:
+        return self.sentinel.master_for(
+            REDIS_SENTINEL_MASTER,
+            password=REDIS_PASSWORD,
+            socket_timeout=5,
+        )
+
+    async def ping(self) -> bool:
+        client = self.get_master()
+        try:
+            pong = await client.ping()
+            return pong is True
+        finally:
+            await client.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ h11==0.16.0
 httpcore==1.0.9
 httpx==0.27.2
 idna==3.9
-instaloader==4.14
+instaloader>=4.14.1
 jiter==0.5.0
 magic-filter==1.0.12
 multidict==6.1.0
@@ -32,3 +32,5 @@ tqdm==4.66.5
 typing_extensions==4.12.2
 urllib3==2.2.3
 yarl==1.18.0
+redis==5.*
+prometheus-client==0.20.0

--- a/session_refresher.py
+++ b/session_refresher.py
@@ -1,0 +1,18 @@
+import asyncio
+from redis_client import RedisClient
+from session_store import IgSessionStore
+from ig_client import IgClient
+from utils.logging_config import logger
+
+
+async def main() -> None:
+    redis = RedisClient().get_master()
+    store = IgSessionStore(redis)
+    client = IgClient(store)
+    await client.login()
+    logger.info("Instagram session refreshed")
+    await redis.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/session_store.py
+++ b/session_store.py
@@ -1,0 +1,34 @@
+import json
+from typing import Optional
+from redis.asyncio.client import Redis
+from settings import IG_SESSION_REFRESH_HOURS
+
+SESSION_KEY = "ig:session:{username}"
+LOCK_KEY = "ig:session:lock"
+TTL = IG_SESSION_REFRESH_HOURS * 3600 + 1800
+
+
+class IgSessionStore:
+    def __init__(self, redis: Redis) -> None:
+        self.redis = redis
+
+    async def get_session(self, username: str) -> Optional[dict]:
+        raw = await self.redis.get(SESSION_KEY.format(username=username))
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def save_session(self, username: str, data: dict) -> None:
+        await self.redis.set(
+            SESSION_KEY.format(username=username),
+            json.dumps(data),
+            ex=TTL,
+        )
+
+    async def touch(self, username: str) -> None:
+        await self.redis.expire(SESSION_KEY.format(username=username), TTL)
+
+    async def acquire_lock(self):
+        lock = self.redis.lock(LOCK_KEY, timeout=300)
+        await lock.acquire()
+        return lock

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,20 @@
+import os
+from typing import Optional
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except ValueError:
+        return default
+
+
+IG_USERNAME: Optional[str] = os.getenv("IG_USERNAME")
+IG_PASSWORD: Optional[str] = os.getenv("IG_PASSWORD")
+
+REDIS_SENTINEL_HOSTS = os.getenv("REDIS_SENTINEL_HOSTS", "")
+REDIS_SENTINEL_MASTER = os.getenv("REDIS_SENTINEL_MASTER", "mymaster")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+
+IG_SESSION_REFRESH_HOURS = _int_env("IG_SESSION_REFRESH_HOURS", 12)
+IG_LOGIN_TIMEOUT_SEC = _int_env("IG_LOGIN_TIMEOUT_SEC", 30)


### PR DESCRIPTION
## Summary
- add modules for Instagram login and session management
- store session information in Redis Sentinel
- add Prometheus metrics placeholders
- document new components in README
- bump requirements to Instaloader 4.14.1 and add redis/prometheus

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ImportError: cannot import name 'SkipHandler')*

------
https://chatgpt.com/codex/tasks/task_e_6878149fa2d8832e8e94a447c6a640ea