### PR TITLE
Refactor OpenAI client to use Responses API

### DIFF
--- a/clients/openai_client.py
+++ b/clients/openai_client.py
@@ -1,8 +1,11 @@
 from contextlib import asynccontextmanager
 from typing import List, Dict, Any
+
 from openai import AsyncOpenAI, OpenAIError, RateLimitError
+
 from utils.logging_config import logger
 from config import OPENAI_API_KEY, TELEGRAM_BOT_TOKEN
+
 
 class OpenAIClient:
     def __init__(self):
@@ -16,7 +19,7 @@ class OpenAIClient:
 
     async def process_message(self, session: Any, user_message: str) -> str:
         try:
-            logger.info("Sending request to OpenAI API")
+            logger.info("Sending request to OpenAI Responses API")
 
             response = await session.process_openai_message(user_message, self)
 
@@ -32,66 +35,55 @@ class OpenAIClient:
             logger.error(f"Unexpected error: {e}")
             return "An unexpected error occurred."
 
-    async def process_message_with_image(self, session: Any, user_message: str, image_urls: List[str]) -> str:
-        # Format the content as a list with text and images
-        message_content = [{"type": "text", "text": user_message}]
+    async def process_message_with_image(
+        self, session: Any, user_message: str, image_urls: List[str]
+    ) -> str:
+        """Send a message with images to OpenAI using the Responses API."""
 
-        # Add all image URLs to the content
+        message_content: List[Dict[str, str]] = [
+            {"type": "input_text", "text": user_message}
+        ]
+
         for url in image_urls:
-            # Telegram file paths need to be converted to full URLs that are accessible from outside
-            # For Telegram Bot API, we need to add the base URL
-            if not url.startswith(('http://', 'https://')):
+            if not url.startswith(("http://", "https://")):
                 full_url = f"https://api.telegram.org/file/bot{self.telegram_bot_token}/{url}"
-                logger.debug(f"Converting relative path to full URL: {url} -> {full_url}")
+                logger.debug(
+                    f"Converting relative path to full URL: {url} -> {full_url}"
+                )
                 url = full_url
+            message_content.append({"type": "input_image", "image_url": url})
 
-            message_content.append({
-                "type": "image_url",
-                "image_url": {
-                    "url": url,
-                    "detail": "auto"
-                }
-            })
-
-        # Get model from session
         model_to_use = session.get_model()
-
-        # if model name starts with o1 use gpt-4o instead for vision
         if model_to_use.startswith("o1"):
             model_to_use = "gpt-4o"
 
         try:
-            logger.info(f"Sending request to OpenAI Vision API with {len(image_urls)} images using model {model_to_use}")
-            logger.debug(f"Final image URLs: {[item['image_url']['url'] for item in message_content if 'image_url' in item]}")
+            logger.info(
+                f"Sending request to OpenAI Responses API with {len(image_urls)} images using model {model_to_use}"
+            )
+            logger.debug(
+                f"Final image URLs: {[item['image_url'] for item in message_content if item['type'] == 'input_image']}"
+            )
 
-            # Get messages from session
-            messages = session.data.get('messages', [])
-
-            # Create a new list with only text messages for history
+            messages = session.data.get("messages", [])
             history_messages = []
             for m in messages:
-                if m["role"] == "user" or m["role"] == "assistant" or m["role"] == "developer":
-                    if isinstance(m["content"], str):
-                        history_messages.append({"role": m["role"], "content": m["content"]})
-                    elif m["role"] == "developer":  # System message
-                        history_messages.append({"role": "system", "content": m["content"]})
+                if m["role"] in ("user", "assistant", "developer"):
+                    role = "system" if m["role"] == "developer" else m["role"]
+                    history_messages.append({"role": role, "content": m["content"]})
 
-            # Add the current message with images
             history_messages.append({"role": "user", "content": message_content})
 
             async with self.get_client() as client:
-                response = await client.chat.completions.create(
+                response = await client.responses.create(
                     model=model_to_use,
-                    messages=history_messages
+                    input=history_messages,
                 )
-            reply = response.choices[0].message.content.strip()
+            reply = response.output[0].content[0].text.strip()
 
-            # Add messages to history (only storing the text part)
             messages.append({"role": "user", "content": user_message + " [with images]"})
             messages.append({"role": "assistant", "content": reply})
-
-            # Update messages in session data
-            session.data['messages'] = messages
+            session.data["messages"] = messages
 
             logger.info(f"Received response from OpenAI API: {reply}")
             return reply
@@ -122,11 +114,12 @@ class OpenAIClient:
                     prompt=prompt,
                     size="1024x1024",
                     quality="medium",
-                    n=1
+                    n=1,
                 )
-            # Return the base64 encoded image
             import base64
+
             return base64.b64decode(response.data[0].b64_json)
         except Exception as e:
             logger.error(f"Error generating image with OpenAI: {e}")
             raise
+

--- a/managers/session_manager.py
+++ b/managers/session_manager.py
@@ -1,7 +1,16 @@
 import asyncio
 import time
 from typing import Dict, List, Union, Optional
-from config import SESSION_EXPIRY, OPENAI_MODEL, ANTHROPIC_MODEL, GEMINI_MODEL, GROK_MODEL, SYSTEM_PROMPT, DEFAULT_MODEL_PROVIDER
+from config import (
+    SESSION_EXPIRY,
+    OPENAI_MODEL,
+    ANTHROPIC_MODEL,
+    GEMINI_MODEL,
+    GROK_MODEL,
+    SYSTEM_PROMPT,
+    DEFAULT_MODEL_PROVIDER,
+    OPENAI_MODELS_REASONING,
+)
 from models.models_list import MODELS, DEFAULT_MODEL
 from utils.logging_config import logger
 
@@ -160,24 +169,24 @@ class Session:
         # Use model from session or client config
         model_id = self.get_model()
 
+        # Prepare messages for the Responses API
+        formatted_messages = []
+        for m in messages:
+            if m["role"] in ("user", "assistant", "developer"):
+                role = "system" if m["role"] == "developer" else m["role"]
+                formatted_messages.append({"role": role, "content": m["content"]})
+
+        kwargs = {"model": model_id, "input": formatted_messages}
+        if model_id in OPENAI_MODELS_REASONING or model_id.startswith("o"):
+            kwargs["reasoning"] = {"effort": "medium"}
+
         try:
-            # Call OpenAI API using the get_client method
             async with openai_client.get_client() as client:
-                response = await client.chat.completions.create(
-                    model=model_id,
-                    messages=[
-                        {"role": m["role"], "content": m["content"]}
-                        for m in messages
-                    ]
-                )
+                response = await client.responses.create(**kwargs)
 
-            # Get assistant's response
-            assistant_message = response.choices[0].message.content
+            assistant_message = response.output[0].content[0].text
 
-            # Add assistant message to history
             messages.append({"role": "assistant", "content": assistant_message})
-
-            # Update messages in session data
             self.data['messages'] = messages
 
             return assistant_message


### PR DESCRIPTION
## Summary
- refactor OpenAI client to use the modern Responses API for text and multimodal chats
- support image messages using `input_text` and `input_image` parts
- update session manager to format history for the Responses API and enable reasoning models

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c33297f994832e9782de9685bcaf9a